### PR TITLE
feat: Add initial set of new grammar pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-
+import Navbar from './components/Navbar';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Grammar from "./pages/WorkHard/Grammar";
 import Phrases from "./pages/WorkHard/Phrases";
@@ -7,12 +7,21 @@ import QuizSection from "./pages/WorkHard/QuizSection";
 import Quotes from "./pages/PlayHard/Quotes";
 import Idioms from "./pages/PlayHard/Idioms";
 import Images from "./pages/PlayHard/Images";
+import Pronouns from './pages/WorkHard/GrammarPages/Pronouns';
+import Tenses from './pages/WorkHard/GrammarPages/Tenses';
+import ModalVerbs from './pages/WorkHard/GrammarPages/ModalVerbs';
+import QuestionForming from './pages/WorkHard/GrammarPages/QuestionForming';
 
 function App() {
   return (
     <Router>
+      <Navbar />
       <Routes>
         <Route path="/work/grammar" element={<Grammar />} />
+        <Route path="/work/grammar/pronouns" element={<Pronouns />} />
+        <Route path="/work/grammar/tenses" element={<Tenses />} />
+        <Route path="/work/grammar/modal-verbs" element={<ModalVerbs />} />
+        <Route path="/work/grammar/question-forming" element={<QuestionForming />} />
         <Route path="/work/phrases" element={<Phrases />} />
         <Route path="/work/good-to-know" element={<GoodToKnow />} />
         <Route path="/work/quiz" element={<QuizSection />} />

--- a/src/pages/PlayHard/Idioms.jsx
+++ b/src/pages/PlayHard/Idioms.jsx
@@ -7,12 +7,12 @@ export default function Idioms() {
       <h1 className="text-3xl font-bold">Idioms</h1>
       {idioms.map((idiom, idx) => (
         <div key={idx} className="border p-4 rounded shadow-sm bg-yellow-50">
-          <p className="font-semibold italic">{idiom.text}</p>
-          {idiom.vocab && (
-            <p className="mt-2 text-sm text-gray-700">
-              <span className="text-yellow-700 font-medium">{idiom.vocab.word}</span>: {idiom.vocab.explanation}
+          <p className="font-semibold italic">{idiom.idiom}</p>
+          {idiom.vocab && idiom.vocab.map((vocabItem, vIndex) => (
+            <p key={vIndex} className="mt-2 text-sm text-gray-700">
+              <span className="text-yellow-700 font-medium">{vocabItem.word}</span>: {vocabItem.meaning}
             </p>
-          )}
+          ))}
         </div>
       ))}
     </div>

--- a/src/pages/PlayHard/Quotes.jsx
+++ b/src/pages/PlayHard/Quotes.jsx
@@ -1,4 +1,4 @@
-import IntroCard from '../../components/common/IntroCard';
+import IntroCard from '../../components/IntroCard';
 import { Quote } from 'lucide-react';
 
 const quotes = [

--- a/src/pages/WorkHard/Grammar.jsx
+++ b/src/pages/WorkHard/Grammar.jsx
@@ -1,10 +1,14 @@
-import IntroCard from '../../components/common/IntroCard';
+import IntroCard from '../../components/IntroCard';
 import { BookOpenCheck } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
-const grammarSections = Array.from({ length: 8 }, (_, i) => ({
-    title: `Grammar Topic ${i + 1}`,
-    description: '',
-}));
+const grammarTopics = [
+  { title: "Pronouns", path: "/work/grammar/pronouns", description: "Learn about different types of pronouns and their uses." },
+  { title: "Tenses", path: "/work/grammar/tenses", description: "Understand the different verb tenses and their applications." },
+  { title: "Modal Verbs", path: "/work/grammar/modal-verbs", description: "Learn about modal auxiliary verbs and their functions." },
+  { title: "Question Forming & WH-Questions", path: "/work/grammar/question-forming", description: "Master how to form questions and use WH-questions." }
+  // More topics will be added here later
+];
 
 const Grammar = () => (
     <div className="p-6 bg-gray-900 min-h-screen text-white">
@@ -15,15 +19,11 @@ const Grammar = () => (
             theme="dark"
         />
 
-        {grammarSections.map((section, idx) => (
-            <div key={idx} className="bg-gray-800 p-4 rounded-lg mb-4">
-                <h3 className="font-bold text-lg mb-2">{section.title}</h3>
-                <p className="mb-2">{section.description || 'Coming soon...'}</p>
-                <div className="bg-gray-700 p-3 rounded mt-2">
-                    <p><strong>Example:</strong> "I have been working all day."</p>
-                    <p className="mt-1 italic">Q: What tense is used here? <br /> A: Present perfect continuous.</p>
-                </div>
-            </div>
+        {grammarTopics.map((topic, idx) => (
+            <Link to={topic.path} key={idx} className="block bg-gray-800 p-4 rounded-lg mb-4 hover:bg-gray-700 transition-colors">
+                <h3 className="font-bold text-lg text-indigo-400 mb-2">{topic.title}</h3>
+                <p className="text-gray-300">{topic.description}</p>
+            </Link>
         ))}
     </div>
 );

--- a/src/pages/WorkHard/GrammarPages/ModalVerbs.jsx
+++ b/src/pages/WorkHard/GrammarPages/ModalVerbs.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const ModalVerbs = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Modal Verbs</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Modal Verbs. This section will cover different types of modal verbs, their uses, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What is a modal verb?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Provide an example of a sentence using 'can'.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Modal Verbs will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ModalVerbs;

--- a/src/pages/WorkHard/GrammarPages/Pronouns.jsx
+++ b/src/pages/WorkHard/GrammarPages/Pronouns.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const Pronouns = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Pronouns</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of pronouns. This section will cover different types of pronouns, their uses, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What is a pronoun?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Provide an example of a possessive pronoun.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Pronouns will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Pronouns;

--- a/src/pages/WorkHard/GrammarPages/QuestionForming.jsx
+++ b/src/pages/WorkHard/GrammarPages/QuestionForming.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const QuestionForming = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Question Forming and WH-Questions</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Question Forming and WH-Questions. This section will cover how to structure questions, use auxiliary verbs, and the role of WH-words.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: How do you form a basic question in English?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: What are the common WH-questions words?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Question Forming will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionForming;

--- a/src/pages/WorkHard/GrammarPages/Tenses.jsx
+++ b/src/pages/WorkHard/GrammarPages/Tenses.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const Tenses = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Tenses</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Tenses. This section will cover different types of tenses, their uses, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What is a verb tense?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Provide an example of the past perfect tense.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Tenses will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Tenses;

--- a/src/pages/WorkHard/Phrases.jsx
+++ b/src/pages/WorkHard/Phrases.jsx
@@ -1,5 +1,5 @@
 // 3. pages/work/Phrases.jsx
-import IntroCard from '../../components/common/IntroCard';
+import IntroCard from '../../components/IntroCard';
 import { MessageSquareQuote } from 'lucide-react';
 
 const sections = ["Elementary", "Intermediate", "Advanced"];


### PR DESCRIPTION
This commit introduces the first set of new grammar subsection pages, accessible from the main Grammar page. It also includes foundational work such as creating a dedicated directory for these pages and correcting an import path.

Changes include:
- Corrected `IntroCard` import in `src/pages/WorkHard/Grammar.jsx`.
- Created directory `src/pages/WorkHard/GrammarPages/`.
- Created placeholder components with styled sections (Text, Q&A, Image) for:
    - `Pronouns.jsx`
    - `Tenses.jsx`
    - `ModalVerbs.jsx`
    - `QuestionForming.jsx`
- Added corresponding routes for these components in `src/App.jsx`.
- Updated `src/pages/WorkHard/Grammar.jsx` to list and link to these new pages, replacing the previous generic topic list.

Further pages are pending completion due to an issue I encountered.