### PR TITLE
feat: Add more grammar pages (Word Order, Quantifiers, etc.)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,10 @@ import Pronouns from './pages/WorkHard/GrammarPages/Pronouns';
 import Tenses from './pages/WorkHard/GrammarPages/Tenses';
 import ModalVerbs from './pages/WorkHard/GrammarPages/ModalVerbs';
 import QuestionForming from './pages/WorkHard/GrammarPages/QuestionForming';
+import WordOrder from './pages/WorkHard/GrammarPages/WordOrder';
+import Quantifiers from './pages/WorkHard/GrammarPages/Quantifiers';
+import ReflexivePronouns from './pages/WorkHard/GrammarPages/ReflexivePronouns';
+import WordTypes from './pages/WorkHard/GrammarPages/WordTypes';
 
 function App() {
   return (
@@ -22,6 +26,10 @@ function App() {
         <Route path="/work/grammar/tenses" element={<Tenses />} />
         <Route path="/work/grammar/modal-verbs" element={<ModalVerbs />} />
         <Route path="/work/grammar/question-forming" element={<QuestionForming />} />
+        <Route path="/work/grammar/word-order" element={<WordOrder />} />
+        <Route path="/work/grammar/quantifiers" element={<Quantifiers />} />
+        <Route path="/work/grammar/reflexive-pronouns" element={<ReflexivePronouns />} />
+        <Route path="/work/grammar/word-types" element={<WordTypes />} />
         <Route path="/work/phrases" element={<Phrases />} />
         <Route path="/work/good-to-know" element={<GoodToKnow />} />
         <Route path="/work/quiz" element={<QuizSection />} />

--- a/src/pages/WorkHard/Grammar.jsx
+++ b/src/pages/WorkHard/Grammar.jsx
@@ -6,7 +6,11 @@ const grammarTopics = [
   { title: "Pronouns", path: "/work/grammar/pronouns", description: "Learn about different types of pronouns and their uses." },
   { title: "Tenses", path: "/work/grammar/tenses", description: "Understand the different verb tenses and their applications." },
   { title: "Modal Verbs", path: "/work/grammar/modal-verbs", description: "Learn about modal auxiliary verbs and their functions." },
-  { title: "Question Forming & WH-Questions", path: "/work/grammar/question-forming", description: "Master how to form questions and use WH-questions." }
+  { title: "Question Forming & WH-Questions", path: "/work/grammar/question-forming", description: "Master how to form questions and use WH-questions." },
+  { title: "Word Order", path: "/work/grammar/word-order", description: "Learn the rules for correct word order in English sentences." },
+  { title: "Quantifiers", path: "/work/grammar/quantifiers", description: "Explore how to use quantifiers with countable and uncountable nouns." },
+  { title: "Reflexive Pronouns", path: "/work/grammar/reflexive-pronouns", description: "Understand how to use reflexive pronouns correctly." },
+  { title: "Word Types", path: "/work/grammar/word-types", description: "Learn about the different categories of words (nouns, verbs, adjectives, etc.)." }
   // More topics will be added here later
 ];
 

--- a/src/pages/WorkHard/GrammarPages/Conditionals.jsx
+++ b/src/pages/WorkHard/GrammarPages/Conditionals.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const Conditionals = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Conditionals</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of different types of Conditionals (Zero, First, Second, Third, Mixed). This section will cover their structure, usage, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What is a zero conditional?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Provide an example of a first conditional sentence.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Conditionals will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Conditionals;

--- a/src/pages/WorkHard/GrammarPages/Quantifiers.jsx
+++ b/src/pages/WorkHard/GrammarPages/Quantifiers.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const Quantifiers = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Quantifiers</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Quantifiers. This section will cover types of quantifiers (e.g., for countable/uncountable nouns), their usage, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What are quantifiers used for?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Give an example of a quantifier used with countable nouns.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Quantifiers will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Quantifiers;

--- a/src/pages/WorkHard/GrammarPages/ReflexivePronouns.jsx
+++ b/src/pages/WorkHard/GrammarPages/ReflexivePronouns.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const ReflexivePronouns = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Reflexive Pronouns</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Reflexive Pronouns. This section will cover what reflexive pronouns are, how they are formed, and their common uses with examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: When are reflexive pronouns used?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Provide a sentence using 'myself'.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Reflexive Pronouns will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReflexivePronouns;

--- a/src/pages/WorkHard/GrammarPages/WordOrder.jsx
+++ b/src/pages/WorkHard/GrammarPages/WordOrder.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const WordOrder = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Word Order</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of Word Order. This section will cover typical sentence structures, variations, and common mistakes.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What is the typical word order in an English sentence?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: How does word order change in questions?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Word Order will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WordOrder;

--- a/src/pages/WorkHard/GrammarPages/WordTypes.jsx
+++ b/src/pages/WorkHard/GrammarPages/WordTypes.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const WordTypes = () => {
+  return (
+    <div className="p-6 bg-gray-100 min-h-screen text-gray-800">
+      <h1 className="text-4xl font-bold text-indigo-700 mb-8">Word Types</h1>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Text Explanation</h2>
+        <p className="text-lg leading-relaxed">
+          Placeholder for a detailed explanation of different Word Types (nouns, verbs, adjectives, etc.). This section will cover their definitions, functions, and examples.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+
+      <div className="mb-10 p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Q&A</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 1: What are the main categories of word types?</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium text-gray-700">Question 2: Give an example of an adverb modifying a verb.</h3>
+            <p className="text-lg text-gray-600 mt-1">Answer: Placeholder for the answer.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 bg-white rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-indigo-600 mb-4">Image Placeholder</h2>
+        <div className="w-full h-64 bg-gray-300 rounded-md flex items-center justify-center">
+          <p className="text-gray-500 text-xl">Image related to Word Types will be displayed here.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WordTypes;


### PR DESCRIPTION
This commit continues the addition of new grammar subsection pages, building upon the previous set.

Changes include the creation of placeholder components, routes in App.jsx, and links in Grammar.jsx for the following topics:
- Word Order
- Quantifiers
- Reflexive Pronouns
- Word Types
- Conditionals (component created, routing and linking pending if not in this commit)

This adds 5 more pages towards the goal of 12 new grammar sections. Each page includes styled placeholders for text explanation, Q&A, and an image.